### PR TITLE
Implement match_name option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This decoder plugin for Embulk supports various archive formats using [Apache Co
   - Auto detect is used when there is no configuration. This can use for a single format. If a file format is solid compression like tar.gz, please set format config explicitly.
   - Some listing formats in [Apache Commons Compress](http://commons.apache.org/proper/commons-compress/) may not work in your environment. I could confirm the following formats work well. Your environment may be able to use other formats listed in the site.
 - **decompress_concatenated**: gzip, bzip2, and xz formats support multiple concatenated streams. The default value of this parameter is true. If you want to disable it, then set to false. See [CompressorStreamFactory.setDecompressConcatenated()](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/compressors/CompressorStreamFactory.html#setDecompressConcatenated(boolean)) in ver.1.9 for more details.
+- **match_name**: Only the files in an archive which match to match_name are processed. match_name is set by regular expression.
 
 ## Formats
 
@@ -70,6 +71,16 @@ in:
   decoders:
     - type: commons-compress
       decompress_concatenated: false
+```
+
+- Set match_name to extract only the files whose suffix is '.csv' from an archive.
+
+```yaml
+in:
+  type: any input plugin type
+  decoders:
+    - type: commons-compress
+      match_name_: ".*\\.csv"
 ```
 
 

--- a/src/main/java/org/embulk/decoder/ArchiveInputStreamIterator.java
+++ b/src/main/java/org/embulk/decoder/ArchiveInputStreamIterator.java
@@ -10,11 +10,17 @@ import org.apache.commons.compress.archivers.ArchiveInputStream;
 class ArchiveInputStreamIterator implements Iterator<InputStream> {
     private ArchiveInputStream ain;
     private ArchiveEntry entry;
+    private String matchRegex = "";
     private boolean endOfArchive = false;
 
     ArchiveInputStreamIterator(ArchiveInputStream ain)
     {
         this.ain = ain;
+    }
+
+    ArchiveInputStreamIterator(ArchiveInputStream ain, String matchRegex) {
+        this.ain = ain;
+        this.matchRegex = matchRegex;
     }
 
     @Override
@@ -60,9 +66,22 @@ class ArchiveInputStreamIterator implements Iterator<InputStream> {
                 return false;
             } else if (entry.isDirectory()) {
                 continue;
+            } else if (!matchName(entry, matchRegex)){
+                continue;
             } else {
                 return true;
             }
+        }
+    }
+
+    private boolean matchName(ArchiveEntry entry, String regex) {
+        String name = entry.getName();
+        if(regex == null || regex.equals("")){
+            return true;
+        } else if(name == null) {
+            return false;
+        } else {
+            return name.matches(regex);
         }
     }
 }

--- a/src/main/java/org/embulk/decoder/CommonsCompressDecoderPlugin.java
+++ b/src/main/java/org/embulk/decoder/CommonsCompressDecoderPlugin.java
@@ -25,6 +25,10 @@ public class CommonsCompressDecoderPlugin
         @ConfigDefault("true")
         public boolean getDecompressConcatenated();
 
+        @Config("match_name")
+        @ConfigDefault("\"\"")
+        public String getMatchName();
+
         @ConfigInject
         public BufferAllocator getBufferAllocator();
     }

--- a/src/main/java/org/embulk/decoder/CommonsCompressProvider.java
+++ b/src/main/java/org/embulk/decoder/CommonsCompressProvider.java
@@ -27,6 +27,7 @@ class CommonsCompressProvider implements Provider {
     private Iterator<InputStream> inputStreamIterator;
     private String[] formats;
     private final boolean decompressConcatenated;
+    private final String matchName;
 
     CommonsCompressProvider(PluginTask task, FileInputInputStream files) {
         this.files = files;
@@ -40,6 +41,7 @@ class CommonsCompressProvider implements Provider {
         }
         this.decompressConcatenated = task == null
             || task.getDecompressConcatenated();
+        this.matchName = (task == null)? "" : task.getMatchName();
     }
 
     @Override
@@ -88,7 +90,9 @@ class CommonsCompressProvider implements Provider {
         in = in.markSupported() ? in : new BufferedInputStream(in);
         try {
             return new ArchiveInputStreamIterator(
-                    createArchiveInputStream(AUTO_DETECT_FORMAT, in));
+                    createArchiveInputStream(AUTO_DETECT_FORMAT, in),
+                    this.matchName
+            );
         } catch (IOException | ArchiveException e) {
             // ArchiveStreamFactory set mark and reset the stream.
             // So, we can use the same stream to check compressor.

--- a/src/test/java/org/embulk/decoder/TestArchiveInputStreamIterator.java
+++ b/src/test/java/org/embulk/decoder/TestArchiveInputStreamIterator.java
@@ -71,6 +71,21 @@ public class TestArchiveInputStreamIterator {
     }
 
     @Test
+    public void testHasNextForNameMatch(@Mocked final ArchiveInputStream ain, @Mocked final ArchiveEntry entry) throws Exception {
+        new NonStrictExpectations() {{
+            ain.getNextEntry(); result = entry; result = entry; result = entry; result = null;
+            entry.getName(); result = "first.csv"; result = "second.txt"; result = "third.csv";
+        }};
+        ArchiveInputStreamIterator it = new ArchiveInputStreamIterator(ain, ".*\\.csv");
+        assertTrue("Verify 1st file match", it.hasNext());
+        assertEquals("Verify ArchiveInputStream is return.", (InputStream)ain, it.next());
+        assertTrue("Verify 3rd file match", it.hasNext());
+        assertEquals("Verify ArchiveInputStream is return.", (InputStream)ain, it.next());
+        assertFalse("Veryfy no more entry because second.txt is skipped.", it.hasNext());
+        assertNull("Verify there is no stream.", it.next());
+    }
+
+    @Test
     public void testArchiveFile() throws Exception {
         InputStream in = getClass().getResourceAsStream("samples.tar");
         ArchiveInputStream ain = new ArchiveStreamFactory().createArchiveInputStream(in);

--- a/src/test/java/org/embulk/decoder/TestCommonsCompressDecoderPlugin.java
+++ b/src/test/java/org/embulk/decoder/TestCommonsCompressDecoderPlugin.java
@@ -563,10 +563,12 @@ public class TestCommonsCompressDecoderPlugin
     private class MockPluginTask implements CommonsCompressDecoderPlugin.PluginTask {
         private final String format;
         private final boolean decompressConcatenated;
+        private final String matchName;
 
         MockPluginTask(String format) {
             this.format = format;
             this.decompressConcatenated = true;
+            this.matchName = "";
         }
 
         @Override
@@ -586,6 +588,11 @@ public class TestCommonsCompressDecoderPlugin
         @Override
         public boolean getDecompressConcatenated() {
             return decompressConcatenated;
+        }
+
+        @Override
+        public String getMatchName() {
+            return matchName;
         }
 
         @Override


### PR DESCRIPTION
This option support that extract only the files which match match_name regex value in an archive file.
If archive file includes no-data file such as PGP signature , README and so on, this option can exclude such files.
