### PR TITLE
support matched name when format is provided

### DIFF
--- a/src/main/java/org/embulk/decoder/CommonsCompressProvider.java
+++ b/src/main/java/org/embulk/decoder/CommonsCompressProvider.java
@@ -124,7 +124,8 @@ class CommonsCompressProvider implements Provider {
             String format = inputFormats[pos];
             if (CommonsCompressUtil.isArchiveFormat(format)) {
                 return new ArchiveInputStreamIterator(
-                        createArchiveInputStream(format, in));
+                        createArchiveInputStream(format, in),
+                        this.matchName);
             } else if (CommonsCompressUtil.isCompressorFormat(format)) {
                 return createInputStreamIterator(inputFormats, pos + 1,
                         createCompressorInputStream(format, in));


### PR DESCRIPTION
When the format is provided, the match name does not work. I guess this could be a bug and I fixed this.

Is there any concern about this? If no, I make this reviewable.