### PR TITLE
ci with java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
+dist: xenial
+jdk:
+  - openjdk8
 script: ./gradlew -DenableIntegrationTest=true gem
-


### PR DESCRIPTION
close #7 
I wonder if this repository is linked to travis CI in order to show ci status in PR.

ci passed!
https://travis-ci.org/github/hata/embulk-decoder-commons-compress/builds/689887984


ref: https://github.com/embulk/embulk-input-jdbc/blob/master/.travis.yml
